### PR TITLE
fix(workspace): refresh document list on upload and poll status live

### DIFF
--- a/src/components/App/IndividualWorkspace/hooks/index.ts
+++ b/src/components/App/IndividualWorkspace/hooks/index.ts
@@ -87,7 +87,17 @@ export function useWorkspaceDocuments(params: GetDocumentsParams) {
       }
     },
     enabled: !!params.workspaceId,
-    staleTime: 1000 * 60 * 2, // 2 minutes
+    staleTime: 1000 * 30, // 30 seconds
+    refetchOnWindowFocus: true, // refresh status when the user returns to the tab
+    // Adaptive polling: only refetch while a document is still waiting for OCR
+    // (mapped from backend UNPROCESSED -> "queued"). Terminal states
+    // (completed / failed / PAID+UNPAID -> "processing") stop the polling so we
+    // don't hammer the API forever. Also pauses automatically in background tabs.
+    refetchInterval: (query) => {
+      const docs = query.state.data?.data ?? [];
+      const hasPending = docs.some((doc) => doc.status === "queued" || doc.status === "uploading");
+      return hasPending ? 5000 : false;
+    },
     retry: (failureCount, error: any) => {
       if (error?.status === 401 || error?.status === 404) {
         return false;

--- a/src/components/App/IndividualWorkspace/hooks/useDocumentHandlers.ts
+++ b/src/components/App/IndividualWorkspace/hooks/useDocumentHandlers.ts
@@ -1,5 +1,7 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useWorkspaceStore } from "../store/workspaceStore";
 import {
+  individualWorkspaceKeys,
   useDeleteDocument,
   useBulkDeleteDocuments,
   useDeleteAllWorkspaceDocuments,
@@ -12,7 +14,9 @@ import {
  * Centralizes document operations and reduces component complexity
  */
 export function useDocumentHandlers() {
+  const queryClient = useQueryClient();
   const documents = useWorkspaceStore((state) => state.documents);
+  const workspace = useWorkspaceStore((state) => state.workspace);
   const selectedDocuments = useWorkspaceStore((state) => state.ui.selectedDocuments);
   const setActiveTab = useWorkspaceStore((state) => state.setActiveTab);
   const toggleDocumentSelection = useWorkspaceStore((state) => state.toggleDocumentSelection);
@@ -70,6 +74,15 @@ export function useDocumentHandlers() {
   const handleUploadComplete = () => {
     // Switch to documents tab after successful upload
     setActiveTab("documents");
+
+    // Uploads go through useS3Upload, which does not touch the React Query cache,
+    // so the documents list stays stale until a full reload. Invalidate the list
+    // (and workspace stats) here so the new document appears immediately.
+    const workspaceId = workspace?.id;
+    if (workspaceId) {
+      queryClient.invalidateQueries({ queryKey: individualWorkspaceKeys.documents(workspaceId) });
+      queryClient.invalidateQueries({ queryKey: individualWorkspaceKeys.workspace(workspaceId) });
+    }
   };
 
   // Handle individual document selection toggle


### PR DESCRIPTION
## Summary
- **Upload refresh:** uploading a document left the list stale until a full page reload — the S3 upload path (`useS3Upload`) never touched the React Query cache. `handleUploadComplete` now invalidates the documents list and workspace stats so the new document appears immediately.
- **Live status:** added adaptive polling to `useWorkspaceDocuments` — refetch every 5s **only** while a document is still `queued`/`uploading`, and stop once all reach a terminal state (`completed`/`failed`/`paid`/`unpaid`). Keeps status current without websockets and without unbounded API calls (also pauses in background tabs).

## Notes
- Polling intentionally does **not** treat `"processing"` as active: the API maps the terminal `PAID`/`UNPAID` backend states to `"processing"`, so polling on it would never stop.

## Testing
- [x] Type-checks (`tsc --noEmit`) clean
- [x] Verified on live test: upload appears without reload; status updates without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)