### PR TITLE
feat(workspace): real pagination for the document list

### DIFF
--- a/src/components/App/IndividualWorkspace/api/index.ts
+++ b/src/components/App/IndividualWorkspace/api/index.ts
@@ -20,6 +20,15 @@ import type {
 
 // Import backend types from upload API
 
+// Shape returned by GET /documents/workspace/:workspaceId (paginated)
+interface BackendPaginatedDocuments {
+  data: DocumentResponse[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
 // Individual Workspace API Functions
 export const individualWorkspaceApi = {
   // Get workspace details by ID
@@ -148,10 +157,11 @@ export const individualWorkspaceApi = {
       const queryString = queryParams.toString();
       const url = `/documents/workspace/${params.workspaceId}${queryString ? `?${queryString}` : ""}`;
 
-      const response = await api.get<DocumentResponse[]>(url);
+      const response = await api.get<BackendPaginatedDocuments>(url);
+      const { data: rawDocuments, total, page, limit, totalPages } = response.data;
 
       // Transform backend DocumentResponse to frontend Document format
-      const documents: Document[] = response.data.map((doc) => ({
+      const documents: Document[] = rawDocuments.map((doc) => ({
         id: doc.id,
         filename: doc.fileName,
         originalName: doc.fileName,
@@ -173,12 +183,7 @@ export const individualWorkspaceApi = {
         ocrResults: undefined, // OCR results are fetched separately
       }));
 
-      // Since backend doesn't provide pagination info, we'll simulate it
-      const total = documents.length;
-      const page = params.page || 1;
-      const limit = params.limit || 20;
-
-      console.log(`🏢 [Individual Workspace API] Documents fetched: ${documents.length}`);
+      console.log(`🏢 [Individual Workspace API] Documents fetched: ${documents.length} of ${total} (page ${page}/${totalPages})`);
 
       return {
         data: {
@@ -186,7 +191,7 @@ export const individualWorkspaceApi = {
           total,
           page,
           limit,
-          totalPages: Math.ceil(total / limit),
+          totalPages,
         },
         success: true,
         status: 200,

--- a/src/components/App/IndividualWorkspace/ui/DocumentsPagination.tsx
+++ b/src/components/App/IndividualWorkspace/ui/DocumentsPagination.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface DocumentsPaginationProps {
+  page: number;
+  totalPages: number;
+  total: number;
+  limit: number;
+  onPageChange: (page: number) => void;
+  isLoading?: boolean;
+}
+
+export function DocumentsPagination({ page, totalPages, total, limit, onPageChange, isLoading }: DocumentsPaginationProps) {
+  // Nothing to paginate
+  if (total === 0) return null;
+
+  const from = (page - 1) * limit + 1;
+  const to = Math.min(page * limit, total);
+
+  const canPrev = page > 1 && !isLoading;
+  const canNext = page < totalPages && !isLoading;
+
+  return (
+    <div className="flex items-center justify-between gap-4 px-3 py-3 border-t border-gray-200 dark:border-gray-700">
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        Showing <span className="font-medium text-gray-900 dark:text-gray-100">{from}</span>–
+        <span className="font-medium text-gray-900 dark:text-gray-100">{to}</span> of{" "}
+        <span className="font-medium text-gray-900 dark:text-gray-100">{total}</span>
+      </p>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onPageChange(page - 1)}
+          disabled={!canPrev}
+          className="inline-flex items-center gap-1 px-3 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          Previous
+        </button>
+
+        <span className="text-sm text-gray-600 dark:text-gray-400">
+          Page <span className="font-medium text-gray-900 dark:text-gray-100">{page}</span> of{" "}
+          <span className="font-medium text-gray-900 dark:text-gray-100">{totalPages}</span>
+        </span>
+
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={!canNext}
+          className="inline-flex items-center gap-1 px-3 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          Next
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/App/IndividualWorkspace/ui/WorkspacePage.tsx
+++ b/src/components/App/IndividualWorkspace/ui/WorkspacePage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Link } from "@/i18n/navigation";
 import { useWorkspaceStore } from "../store/workspaceStore";
 import { useWorkspaceDetails, useWorkspaceDocuments } from "../hooks";
@@ -9,8 +10,11 @@ import { WorkspaceHeader } from "./WorkspaceHeader";
 import { TabNavigation } from "./TabNavigation";
 import { UploadZone } from "./UploadZone";
 import { DocumentTable } from "./DocumentTable";
+import { DocumentsPagination } from "./DocumentsPagination";
 import { WorkspacePageSkeleton } from "./WorkspacePageSkeleton";
 import type { WorkspacePageProps } from "../types";
+
+const PAGE_SIZE = 20;
 
 export function WorkspacePage({ workspaceId }: WorkspacePageProps) {
   // Store state
@@ -23,16 +27,35 @@ export function WorkspacePage({ workspaceId }: WorkspacePageProps) {
   const setShowSettings = useWorkspaceStore((state) => state.setShowSettings);
   const setActiveTab = useWorkspaceStore((state) => state.setActiveTab);
 
+  // Pagination state
+  const [page, setPage] = useState(1);
+
+  // Reset to the first page whenever the query criteria change
+  useEffect(() => {
+    setPage(1);
+  }, [filters, search, sort]);
+
   // Data fetching
   const { isLoading: isLoadingWorkspace, error: workspaceError } = useWorkspaceDetails(workspaceId);
-  const { isLoading: isLoadingDocuments } = useWorkspaceDocuments({
+  const { isLoading: isLoadingDocuments, data: documentsPage } = useWorkspaceDocuments({
     workspaceId,
-    page: 1,
-    limit: 50,
+    page,
+    limit: PAGE_SIZE,
     filters,
     search,
     sort,
   });
+
+  const totalDocuments = documentsPage?.total ?? documents.length;
+  const totalPages = documentsPage?.totalPages ?? 1;
+
+  // Clamp the page if the total shrinks (e.g. after deletions) so we never
+  // sit on an empty page beyond the last one.
+  useEffect(() => {
+    if (page > totalPages && totalPages >= 1) {
+      setPage(totalPages);
+    }
+  }, [page, totalPages]);
 
   // Custom hooks for complex logic
   const { hasCachedData } = useWorkspaceDataManagement(workspaceId);
@@ -94,7 +117,7 @@ export function WorkspacePage({ workspaceId }: WorkspacePageProps) {
         <WorkspaceHeader workspace={workspace} onSettingsClick={handleSettingsClick} />
 
         <div className="border border-gray-300 dark:border-gray-700 rounded-xl">
-          <TabNavigation activeTab={ui.activeTab} onTabChange={handleTabChange} documentCount={documents.length} />
+          <TabNavigation activeTab={ui.activeTab} onTabChange={handleTabChange} documentCount={totalDocuments} />
           <div className="p-2">
             {ui.activeTab === "upload" && (
               <div className="space-y-6">
@@ -107,23 +130,33 @@ export function WorkspacePage({ workspaceId }: WorkspacePageProps) {
             )}
 
             {ui.activeTab === "documents" && (
-              <DocumentTable
-                documents={documents}
-                selectedDocuments={ui.selectedDocuments}
-                onDocumentSelect={documentHandlers.handleDocumentSelect}
-                onDocumentToggle={documentHandlers.handleDocumentToggle}
-                onSelectAll={documentHandlers.handleSelectAll}
-                allSelected={allSelected}
-                someSelected={someSelected}
-                onDocumentDelete={documentHandlers.handleDocumentDelete}
-                onDocumentReprocess={documentHandlers.handleDocumentReprocess}
-                onDocumentDownload={documentHandlers.handleDocumentDownload}
-                onBulkDelete={documentHandlers.handleBulkDelete}
-                onBulkReprocess={documentHandlers.handleBulkReprocess}
-                onBulkExport={documentHandlers.handleBulkExport}
-                onExportAll={documentHandlers.handleExportAll}
-                isLoading={isLoadingDocuments}
-              />
+              <>
+                <DocumentTable
+                  documents={documents}
+                  selectedDocuments={ui.selectedDocuments}
+                  onDocumentSelect={documentHandlers.handleDocumentSelect}
+                  onDocumentToggle={documentHandlers.handleDocumentToggle}
+                  onSelectAll={documentHandlers.handleSelectAll}
+                  allSelected={allSelected}
+                  someSelected={someSelected}
+                  onDocumentDelete={documentHandlers.handleDocumentDelete}
+                  onDocumentReprocess={documentHandlers.handleDocumentReprocess}
+                  onDocumentDownload={documentHandlers.handleDocumentDownload}
+                  onBulkDelete={documentHandlers.handleBulkDelete}
+                  onBulkReprocess={documentHandlers.handleBulkReprocess}
+                  onBulkExport={documentHandlers.handleBulkExport}
+                  onExportAll={documentHandlers.handleExportAll}
+                  isLoading={isLoadingDocuments}
+                />
+                <DocumentsPagination
+                  page={page}
+                  totalPages={totalPages}
+                  total={totalDocuments}
+                  limit={PAGE_SIZE}
+                  onPageChange={setPage}
+                  isLoading={isLoadingDocuments}
+                />
+              </>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
The document list now uses **real pagination** instead of faking totals from the returned array:
- Consumes the backend's paginated response `{ data, total, page, limit, totalPages }`
- Page state in `WorkspacePage` (20 per page); resets to page 1 when filters/search/sort change; clamps the page when the total shrinks (e.g. after deletions)
- New `DocumentsPagination` control: prev/next + "Showing X–Y of Z / Page N of M"
- Tab badge now shows the true total, not just the current page count

## ⚠️ Depends on backend
Requires the paginated `GET /documents/workspace/:workspaceId` change (ImranAhmed26/devcom-backend PR #29). This is a breaking response-shape change — **deploy backend first**, or the list will error against the old array response.

## Out of scope (deferred)
- Backend still ignores `filters`/`search`/`sort` — separate task.

## Testing
- [x] `tsc --noEmit` + eslint clean
- [ ] Manual: page through a workspace with >20 documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)