### PR TITLE
fix(auth): remove unused tokenInfo to unblock Vercel build

### DIFF
--- a/src/lib/auth/authStore.ts
+++ b/src/lib/auth/authStore.ts
@@ -94,7 +94,6 @@ export const useAuthStore = create<AuthState>()(
       initializeAuth: () => {
         try {
           const { user: storedUser } = AuthStorage.getAuthData();
-          const tokenInfo = AuthStorage.getTokenExpirationInfo();
 
           if (storedUser && AuthStorage.isAuthenticated()) {
             set({


### PR DESCRIPTION
## Summary
Vercel deployment was failing:
\`\`\`
./src/lib/auth/authStore.ts
97:17  Error: 'tokenInfo' is assigned a value but never used.  @typescript-eslint/no-unused-vars
\`\`\`
`initializeAuth` assigned `tokenInfo` from `getTokenExpirationInfo()` but never used it. `next build` runs ESLint across the whole project and fails on `no-unused-vars`, breaking the deploy. Removed the dead line.

## Testing
- [x] Full `npm run build` (same as Vercel) passes — no ESLint errors (only a pre-existing `<img>` warning)

## Note
This dead line is on `main`, so other open frontend branches inherited it and their previews will fail until they're rebased on top of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)