### PR TITLE
feat(app): add error boundaries and stop duplicate retry storms

### DIFF
--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import { Link } from "@/i18n/navigation";
+
+// Catches render/runtime errors in any route under [locale] (dashboard,
+// workspace, etc.) so the app degrades to a friendly page instead of the
+// blank "missing required error components" screen.
+export default function LocaleError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    // Surface the real error (and hook up error reporting here later).
+    console.error("🧯 [error boundary] Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="min-h-[70dvh] flex items-center justify-center p-6">
+      <div className="max-w-md w-full text-center rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-8 shadow-sm">
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Something went wrong</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+          We couldn&apos;t load this page. This is usually temporary — please try again in a moment.
+          {error?.digest ? (
+            <span className="block mt-2 text-xs text-gray-400 dark:text-gray-500">Reference: {error.digest}</span>
+          ) : null}
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={() => reset()}
+            className="inline-flex items-center px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors"
+          >
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="inline-flex items-center px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            Go home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,23 @@
+import { Link } from "@/i18n/navigation";
+
+// Rendered when notFound() is called (e.g. unknown locale in the layout) or a
+// route doesn't match. Keeps the user in a recoverable state.
+export default function NotFound() {
+  return (
+    <div className="min-h-[70dvh] flex items-center justify-center p-6">
+      <div className="max-w-md w-full text-center">
+        <p className="text-5xl font-bold text-indigo-600 mb-2">404</p>
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">Page not found</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+          The page you&apos;re looking for doesn&apos;t exist or may have moved.
+        </p>
+        <Link
+          href="/"
+          className="inline-flex items-center px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors"
+        >
+          Back home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+// Catches errors thrown in the root layout / locale layout, where no other
+// error boundary can render. Must define its own <html>/<body>.
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <html lang="en">
+      <body className="antialiased bg-[#f5f5f5] text-gray-700 dark:bg-[#1a2744] dark:text-indigo-200">
+        <div className="min-h-screen flex items-center justify-center p-6">
+          <div className="max-w-md text-center">
+            <h1 className="text-2xl font-bold mb-3">Something went wrong</h1>
+            <p className="text-sm opacity-80 mb-6">
+              The application ran into an unexpected error. Please try again.
+              {error?.digest ? <span className="block mt-2 text-xs opacity-60">Reference: {error.digest}</span> : null}
+            </p>
+            <button
+              onClick={() => reset()}
+              className="inline-flex items-center px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -15,8 +15,10 @@ const queryClient = new QueryClient({
         if (error?.status >= 400 && error?.status < 500) {
           return false;
         }
-        return failureCount < 3;
+        return failureCount < 2;
       },
+      // Exponential backoff (capped) so a struggling backend gets breathing room
+      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 15000),
     },
     mutations: {
       retry: (failureCount, error: any) => {

--- a/src/lib/api/api.tsx
+++ b/src/lib/api/api.tsx
@@ -207,11 +207,13 @@ class Api {
   }
 
   private shouldRetry(error: AxiosError): boolean {
-    // Retry on network errors, timeouts, and 5xx server errors
+    // Only retry genuine transport failures here. 5xx retries are intentionally
+    // NOT handled at this layer: React Query already retries failed queries with
+    // backoff, and retrying 5xx in both places multiplies requests (~4x4) and can
+    // hammer a backend that is mid-deploy/recovering.
     return (
       !error.response || // Network error
-      error.code === "ECONNABORTED" || // Timeout
-      (error.response.status >= 500 && error.response.status < 600) // Server errors
+      error.code === "ECONNABORTED" // Timeout
     );
   }
 
@@ -419,7 +421,7 @@ class Api {
 // Create API instance with validated environment configuration
 const api = new Api({
   baseURL: env.apiUrl,
-  retries: 3,
+  retries: 2, // transport-level retries only (network/timeout); see shouldRetry
   retryDelay: 1000, // 1 second base delay
 });
 


### PR DESCRIPTION
## Context
During a backend deploy the app showed a blank "missing required error components" white screen and fired near-infinite API calls at the failing backend. Both are addressed here.

## Changes
**1. Error boundaries** (the app had none):
- `global-error.tsx` — root/locale layout crashes
- `[locale]/error.tsx` — dashboard + all locale routes → friendly "Try again / Go home" page, logs the real error
- `[locale]/not-found.tsx` — proper 404 (`notFound()` was called with no page to render)

This also stops the reload loop: with a boundary, Next renders the error page instead of hard-refreshing forever.

**2. De-duplicated retries** (were stacked in two layers, ~4×4 requests per mount):
- Axios client retries **only** transport failures (network/timeout), no 5xx
- React Query is the single 5xx authority — capped at **2** retries with exponential backoff (max 15s)

## Testing
- [x] Full `npm run build` (same as Vercel) passes

## Note
Stacked on the lint-fix branch (PandaParse-frontend #17) so the build passes. **Merge #17 first**; afterwards this diff shows only the error-handling changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)