### PR TITLE
fix(workspace): handle paginated response in getWorkspaceDetails

### DIFF
--- a/src/components/App/IndividualWorkspace/api/index.ts
+++ b/src/components/App/IndividualWorkspace/api/index.ts
@@ -39,19 +39,32 @@ export const individualWorkspaceApi = {
       // Since the backend doesn't have a dedicated workspace endpoint,
       // we'll create a workspace object by aggregating document data
 
-      // First, try to get documents to calculate stats
+      // First, try to get documents to calculate stats.
+      // The endpoint is paginated ({ data, total, ... }), but tolerate the older
+      // plain-array shape too so this doesn't break during the rollout.
       let documents: DocumentResponse[] = [];
+      let totalDocuments = 0;
       try {
-        const documentsResponse = await api.get<DocumentResponse[]>(`/documents/workspace/${workspaceId}`);
-        documents = documentsResponse.data;
+        const documentsResponse = await api.get<DocumentResponse[] | BackendPaginatedDocuments>(
+          `/documents/workspace/${workspaceId}`
+        );
+        const body = documentsResponse.data;
+        if (Array.isArray(body)) {
+          documents = body;
+          totalDocuments = body.length;
+        } else {
+          documents = body?.data ?? [];
+          totalDocuments = body?.total ?? documents.length;
+        }
       } catch (docError) {
         console.warn(`🏢 [Individual Workspace API] Could not fetch documents for stats:`, docError);
         // Continue with empty documents array
       }
 
-      // Calculate stats from documents
+      // Calculate stats from documents. Note: status counts reflect the first
+      // page of documents when paginated; totalDocuments uses the real total.
       const stats: WorkspaceStats = {
-        totalDocuments: documents.length,
+        totalDocuments,
         processingDocuments: documents.filter((doc) => doc.status === "UNPROCESSED").length,
         completedDocuments: documents.filter((doc) => doc.status === "PROCESSED").length,
         failedDocuments: documents.filter((doc) => doc.status === "FLAGGED").length,


### PR DESCRIPTION
## Summary
Follow-up to #16 (document pagination). That PR changed `GET /documents/workspace/:id` to return a paginated object `{ data, total, page, limit, totalPages }` and updated `getWorkspaceDocuments`, but **`getWorkspaceDetails` calls the same endpoint** and still treated the body as an array — causing a live crash:

```
TypeError: documents.filter is not a function  (Object.getWorkspaceDetails)
```

## Fix
`getWorkspaceDetails` now reads the array from the paginated shape (and still tolerates the old array shape during rollout), and uses the real `total` for `totalDocuments`.

## Known limitation (documented in code)
Status breakdown (processing/completed/failed) now reflects only the first page of documents; `totalDocuments` is accurate. Exact status counts would need a dedicated backend stats endpoint — out of scope here.

## Testing
- [x] Full `npm run build` passes
- [x] Verified locally against the paginated backend — workspace document page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)