### PR TITLE
fix(workspace): document list pagination fixes (shape, controls, 12/page)

### DIFF
--- a/src/components/App/IndividualWorkspace/api/index.ts
+++ b/src/components/App/IndividualWorkspace/api/index.ts
@@ -39,19 +39,32 @@ export const individualWorkspaceApi = {
       // Since the backend doesn't have a dedicated workspace endpoint,
       // we'll create a workspace object by aggregating document data
 
-      // First, try to get documents to calculate stats
+      // First, try to get documents to calculate stats.
+      // The endpoint is paginated ({ data, total, ... }), but tolerate the older
+      // plain-array shape too so this doesn't break during the rollout.
       let documents: DocumentResponse[] = [];
+      let totalDocuments = 0;
       try {
-        const documentsResponse = await api.get<DocumentResponse[]>(`/documents/workspace/${workspaceId}`);
-        documents = documentsResponse.data;
+        const documentsResponse = await api.get<DocumentResponse[] | BackendPaginatedDocuments>(
+          `/documents/workspace/${workspaceId}`
+        );
+        const body = documentsResponse.data;
+        if (Array.isArray(body)) {
+          documents = body;
+          totalDocuments = body.length;
+        } else {
+          documents = body?.data ?? [];
+          totalDocuments = body?.total ?? documents.length;
+        }
       } catch (docError) {
         console.warn(`🏢 [Individual Workspace API] Could not fetch documents for stats:`, docError);
         // Continue with empty documents array
       }
 
-      // Calculate stats from documents
+      // Calculate stats from documents. Note: status counts reflect the first
+      // page of documents when paginated; totalDocuments uses the real total.
       const stats: WorkspaceStats = {
-        totalDocuments: documents.length,
+        totalDocuments,
         processingDocuments: documents.filter((doc) => doc.status === "UNPROCESSED").length,
         completedDocuments: documents.filter((doc) => doc.status === "PROCESSED").length,
         failedDocuments: documents.filter((doc) => doc.status === "FLAGGED").length,

--- a/src/components/App/IndividualWorkspace/hooks/index.ts
+++ b/src/components/App/IndividualWorkspace/hooks/index.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import { individualWorkspaceApi } from "../api";
 import { useWorkspaceStore } from "../store/workspaceStore";
 import type { GetDocumentsParams, UploadDocumentRequest, UpdateWorkspaceRequest, ExportRequest } from "../types";
@@ -88,6 +88,10 @@ export function useWorkspaceDocuments(params: GetDocumentsParams) {
     },
     enabled: !!params.workspaceId,
     staleTime: 1000 * 30, // 30 seconds
+    // Keep showing the current page's data while the next page loads, so
+    // pagination metadata (total/totalPages) stays valid during navigation
+    // instead of momentarily collapsing to undefined.
+    placeholderData: keepPreviousData,
     refetchOnWindowFocus: true, // refresh status when the user returns to the tab
     // Adaptive polling: only refetch while a document is still waiting for OCR
     // (mapped from backend UNPROCESSED -> "queued"). Terminal states

--- a/src/components/App/IndividualWorkspace/ui/DocumentsPagination.tsx
+++ b/src/components/App/IndividualWorkspace/ui/DocumentsPagination.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
 
 interface DocumentsPaginationProps {
   page: number;
@@ -23,10 +23,18 @@ export function DocumentsPagination({ page, totalPages, total, limit, onPageChan
 
   return (
     <div className="flex items-center justify-between gap-4 px-3 py-3 border-t border-gray-200 dark:border-gray-700">
-      <p className="text-sm text-gray-600 dark:text-gray-400">
-        Showing <span className="font-medium text-gray-900 dark:text-gray-100">{from}</span>–
-        <span className="font-medium text-gray-900 dark:text-gray-100">{to}</span> of{" "}
-        <span className="font-medium text-gray-900 dark:text-gray-100">{total}</span>
+      <p className="text-sm text-gray-600 dark:text-gray-400 flex items-center gap-2">
+        <span>
+          Showing <span className="font-medium text-gray-900 dark:text-gray-100">{from}</span>–
+          <span className="font-medium text-gray-900 dark:text-gray-100">{to}</span> of{" "}
+          <span className="font-medium text-gray-900 dark:text-gray-100">{total}</span>
+        </span>
+        {isLoading && (
+          <span className="inline-flex items-center gap-1 text-indigo-600 dark:text-indigo-400">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Updating…
+          </span>
+        )}
       </p>
 
       <div className="flex items-center gap-2">

--- a/src/components/App/IndividualWorkspace/ui/WorkspacePage.tsx
+++ b/src/components/App/IndividualWorkspace/ui/WorkspacePage.tsx
@@ -14,7 +14,7 @@ import { DocumentsPagination } from "./DocumentsPagination";
 import { WorkspacePageSkeleton } from "./WorkspacePageSkeleton";
 import type { WorkspacePageProps } from "../types";
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 12;
 
 export function WorkspacePage({ workspaceId }: WorkspacePageProps) {
   // Store state

--- a/src/components/App/IndividualWorkspace/ui/WorkspacePage.tsx
+++ b/src/components/App/IndividualWorkspace/ui/WorkspacePage.tsx
@@ -26,6 +26,7 @@ export function WorkspacePage({ workspaceId }: WorkspacePageProps) {
   const ui = useWorkspaceStore((state) => state.ui);
   const setShowSettings = useWorkspaceStore((state) => state.setShowSettings);
   const setActiveTab = useWorkspaceStore((state) => state.setActiveTab);
+  const setDocuments = useWorkspaceStore((state) => state.setDocuments);
 
   // Pagination state
   const [page, setPage] = useState(1);
@@ -37,7 +38,11 @@ export function WorkspacePage({ workspaceId }: WorkspacePageProps) {
 
   // Data fetching
   const { isLoading: isLoadingWorkspace, error: workspaceError } = useWorkspaceDetails(workspaceId);
-  const { isLoading: isLoadingDocuments, data: documentsPage } = useWorkspaceDocuments({
+  const {
+    isLoading: isLoadingDocuments,
+    isFetching: isFetchingDocuments,
+    data: documentsPage,
+  } = useWorkspaceDocuments({
     workspaceId,
     page,
     limit: PAGE_SIZE,
@@ -49,13 +54,21 @@ export function WorkspacePage({ workspaceId }: WorkspacePageProps) {
   const totalDocuments = documentsPage?.total ?? documents.length;
   const totalPages = documentsPage?.totalPages ?? 1;
 
-  // Clamp the page if the total shrinks (e.g. after deletions) so we never
-  // sit on an empty page beyond the last one.
+  // Keep the table (store) in sync with the current page's data, including
+  // cached navigations where queryFn doesn't re-run.
   useEffect(() => {
-    if (page > totalPages && totalPages >= 1) {
+    if (documentsPage?.data) {
+      setDocuments(documentsPage.data);
+    }
+  }, [documentsPage, setDocuments]);
+
+  // Clamp the page if the total shrinks (e.g. after deletions) so we never
+  // sit on an empty page beyond the last one. Don't clamp mid-fetch.
+  useEffect(() => {
+    if (!isFetchingDocuments && page > totalPages && totalPages >= 1) {
       setPage(totalPages);
     }
-  }, [page, totalPages]);
+  }, [page, totalPages, isFetchingDocuments]);
 
   // Custom hooks for complex logic
   const { hasCachedData } = useWorkspaceDataManagement(workspaceId);
@@ -154,7 +167,7 @@ export function WorkspacePage({ workspaceId }: WorkspacePageProps) {
                   total={totalDocuments}
                   limit={PAGE_SIZE}
                   onPageChange={setPage}
-                  isLoading={isLoadingDocuments}
+                  isLoading={isFetchingDocuments}
                 />
               </>
             )}


### PR DESCRIPTION
Consolidated pagination fixes for the workspace document list (folds in what was #19).

## Changes
1. **getWorkspaceDetails paginated-response fix** (live regression from #16): the endpoint now returns `{ data, total, ... }`; `getWorkspaceDetails` still treated it as an array → `documents.filter is not a function`. Now reads the array from the paginated shape (tolerates old array shape) and uses the real `total`.
2. **Pager controls lag + loading feedback**: `placeholderData: keepPreviousData` keeps pagination metadata valid during navigation (no clamp misfire, correct Prev/Next state); store synced from current page's data so cached navigations update the table; clamp guarded mid-fetch; "Updating…" indicator + disabled buttons while fetching.
3. **Page size set to 12.**

## Testing
- [x] Full `npm run build` passes (run in isolated worktree)
- [x] Verified locally against the paginated backend

Supersedes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)