### PR TITLE
feat(seo): rebrand to OCRParse + full metadata, sitemap, robots, OG & AI discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Panda Parse
+# OCRParse
 
 A modern OCR (Optical Character Recognition) dashboard application that extracts structured data from invoices, receipts, and documents.
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -6,7 +6,9 @@
   "landing": {
     "banner": {
       "title": "Erstellen Sie KI-Tools mit OCR in wenigen Minuten",
-      "highlightedWords": ["ocr"],
+      "highlightedWords": [
+        "ocr"
+      ],
       "subTitle": "Transparente Preise, Schnellere Abläufe, Niedrigere Kosten.",
       "description": "Beginnen Sie noch heute mit der Extraktion strukturierter Daten aus Dokumenten.",
       "button": {
@@ -19,6 +21,24 @@
           "link": "/learn-more"
         }
       }
+    }
+  },
+  "Meta": {
+    "home": {
+      "title": "OCRParse — Präzise OCR für Rechnungen, Belege und Dokumente",
+      "description": "Verwandeln Sie Rechnungen, Belege und Dokumente in Sekunden in strukturierte JSON/CSV-Daten. Unsere KI übernimmt die Komplexität, damit sich Ihr Finanzteam auf das Wesentliche konzentrieren kann."
+    },
+    "about": {
+      "title": "Über uns",
+      "description": "OCRParse verwandelt Rechnungen, Belege und Dokumente mit KI-gestützter OCR in saubere, strukturierte Daten — entwickelt für Finanzteams, die Genauigkeit ohne manuelle Arbeit wollen."
+    },
+    "pricing": {
+      "title": "Preise",
+      "description": "Einfache, transparente Preise für OCRParse. Extrahieren Sie strukturierte Daten aus Rechnungen und Belegen in großem Umfang — zahlen Sie nur für das, was Sie nutzen."
+    },
+    "contact": {
+      "title": "Kontakt",
+      "description": "Kontaktieren Sie das OCRParse-Team zu Datenextraktion aus Dokumenten, Preisen oder Integrationen. Wir helfen Ihnen gerne."
     }
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,7 +6,9 @@
   "landing": {
     "banner": {
       "title": "Accurate OCR for invoices, receipts, and documents",
-      "highlightedWords": ["ocr"],
+      "highlightedWords": [
+        "ocr"
+      ],
       "subTitle": "Transparent Pricing, Faster Operations, Lower Costs.",
       "description": "Transform invoices, receipts, and documents into structured JSON/CSV data in seconds. Our AI handles the complexity so your finance team can focus on what matters.",
       "button": {
@@ -19,6 +21,24 @@
           "link": "/learn-more"
         }
       }
+    }
+  },
+  "Meta": {
+    "home": {
+      "title": "OCRParse — Accurate OCR for invoices, receipts & documents",
+      "description": "Transform invoices, receipts, and documents into structured JSON/CSV data in seconds. Our AI handles the complexity so your finance team can focus on what matters."
+    },
+    "about": {
+      "title": "About",
+      "description": "OCRParse turns invoices, receipts, and documents into clean, structured data with AI-powered OCR — built for finance teams that want accuracy without the manual work."
+    },
+    "pricing": {
+      "title": "Pricing",
+      "description": "Simple, transparent pricing for OCRParse. Extract structured data from invoices and receipts at scale — pay only for what you use."
+    },
+    "contact": {
+      "title": "Contact",
+      "description": "Get in touch with the OCRParse team about document data extraction, pricing, or integrations. We are happy to help."
     }
   }
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -6,7 +6,9 @@
   "landing": {
     "banner": {
       "title": "Bouw AI-tools met OCR in enkele minuten",
-      "highlightedWords": ["ocr"],
+      "highlightedWords": [
+        "ocr"
+      ],
       "subTitle": "Transparante Prijzen, Snellere Processen, Lagere Kosten.",
       "description": "Begin vandaag nog met het extraheren van gestructureerde gegevens uit documenten.",
       "button": {
@@ -19,6 +21,24 @@
           "link": "/learn-more"
         }
       }
+    }
+  },
+  "Meta": {
+    "home": {
+      "title": "OCRParse — Nauwkeurige OCR voor facturen, bonnen en documenten",
+      "description": "Zet facturen, bonnen en documenten in seconden om in gestructureerde JSON/CSV-gegevens. Onze AI regelt de complexiteit zodat je financiële team zich kan richten op wat telt."
+    },
+    "about": {
+      "title": "Over ons",
+      "description": "OCRParse zet facturen, bonnen en documenten om in schone, gestructureerde gegevens met AI-gestuurde OCR — gebouwd voor financiële teams die nauwkeurigheid willen zonder handwerk."
+    },
+    "pricing": {
+      "title": "Prijzen",
+      "description": "Eenvoudige, transparante prijzen voor OCRParse. Extraheer op grote schaal gestructureerde gegevens uit facturen en bonnen — betaal alleen voor wat je gebruikt."
+    },
+    "contact": {
+      "title": "Contact",
+      "description": "Neem contact op met het OCRParse-team over data-extractie uit documenten, prijzen of integraties. We helpen je graag."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "dev:host": "npm run dev -- --hostname 0.0.0.0 --port 3210",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,22 @@
+# OCRParse
+
+> OCRParse is an AI-powered OCR platform that turns invoices, receipts, and business documents into structured JSON/CSV data in seconds. It is built for finance and operations teams that need accurate document data extraction without manual entry.
+
+## What it does
+- Extracts structured data — vendor, invoice number, dates, subtotal, tax, total, and line items — from invoices, receipts, purchase orders, and shipping documents.
+- Accepts PDF, JPEG, PNG, and TIFF files and outputs clean JSON and CSV.
+- Achieves 99%+ accuracy on standard documents and 95%+ on complex layouts, with per-field confidence scores and a built-in review-and-correction interface.
+- Cross-field validation (e.g. subtotal + tax = total) flags likely extraction errors for review.
+- GDPR compliant: data is processed in EU-based data centers and encrypted in transit and at rest.
+- Offers a REST API and webhooks for integration with accounting and ERP systems. A 14-day free trial is available with no credit card required.
+
+## Pages
+- [Home](https://www.ocrparse.com/en): Product overview, features, and FAQ.
+- [Pricing](https://www.ocrparse.com/en/pricing): Plans and pricing.
+- [Contact](https://www.ocrparse.com/en/contact): Get in touch with the team.
+
+## Key facts
+- Name: OCRParse
+- Category: OCR, document data extraction, accounts payable (AP) automation
+- Website: https://www.ocrparse.com
+- Languages: English, Dutch (nl), German (de)

--- a/src/app/[locale]/(app)/layout.tsx
+++ b/src/app/[locale]/(app)/layout.tsx
@@ -1,6 +1,12 @@
+import type { Metadata } from "next";
 import AppNavbar from "@/components/Navbar/AppNavbar";
 import { AppSidebar } from "@/components/Sidebar";
 import { ProtectedRoute } from "@/components/Auth/RouteGuard";
+
+// The authenticated app is private — never index any of it.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default function LocaleLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/app/[locale]/(app)/workspace/[id]/document/[documentId]/page.tsx
+++ b/src/app/[locale]/(app)/workspace/[id]/document/[documentId]/page.tsx
@@ -11,7 +11,7 @@ interface DocumentEditorRouteProps {
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
-    title: "Document Editor | Panda Parse",
+    title: "Document Editor | OCRParse",
     description: "Review and correct extracted document data",
   };
 }

--- a/src/app/[locale]/(app)/workspace/[id]/page.tsx
+++ b/src/app/[locale]/(app)/workspace/[id]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: WorkspacePageProps): Promise<
   // TODO: Fetch workspace name from API to show in title
   // For now, use a generic title instead of showing the workspace ID
   return {
-    title: `Workspace | Panda Parse`,
+    title: `Workspace | OCRParse`,
     description: "Individual workspace for document processing and OCR management",
   };
 }

--- a/src/app/[locale]/(home)/about/page.tsx
+++ b/src/app/[locale]/(home)/about/page.tsx
@@ -1,5 +1,16 @@
 import React from "react";
+import type { Metadata } from "next";
+import { pageMetadata } from "@/lib/seoMetadata";
 // import About from '@/components/Home/About';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return pageMetadata(locale, "about", "/about");
+}
 
 const page = () => {
   return <div>{/* <About /> */}</div>;

--- a/src/app/[locale]/(home)/auth/login/page.tsx
+++ b/src/app/[locale]/(home)/auth/login/page.tsx
@@ -1,6 +1,13 @@
 import React from "react";
+import type { Metadata } from "next";
 import Login from "@/components/Auth/Login";
 import { PublicRoute } from "@/components/Auth/RouteGuard";
+
+// Utility page — keep it out of the search index.
+export const metadata: Metadata = {
+  title: "Sign in",
+  robots: { index: false, follow: false },
+};
 
 const page = () => {
   return (

--- a/src/app/[locale]/(home)/auth/register/page.tsx
+++ b/src/app/[locale]/(home)/auth/register/page.tsx
@@ -1,6 +1,13 @@
 import React from "react";
+import type { Metadata } from "next";
 import Register from "@/components/Auth/Register";
 import { PublicRoute } from "@/components/Auth/RouteGuard";
+
+// Utility page — keep it out of the search index.
+export const metadata: Metadata = {
+  title: "Create account",
+  robots: { index: false, follow: false },
+};
 
 const page = () => {
   return (

--- a/src/app/[locale]/(home)/contact/page.tsx
+++ b/src/app/[locale]/(home)/contact/page.tsx
@@ -1,5 +1,16 @@
 import React from "react";
+import type { Metadata } from "next";
 import Contact from "@/components/Home/Resources/Contact";
+import { pageMetadata } from "@/lib/seoMetadata";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return pageMetadata(locale, "contact", "/contact");
+}
 
 const page = () => {
   return (

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -8,6 +8,8 @@ import Pricing from "@/components/Home/Pricing";
 import FAQ from "@/components/Home/FAQ";
 import FinalCTA from "@/components/Home/FinalCTA";
 import { pageMetadata } from "@/lib/seoMetadata";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { faqs } from "@/constants/faq";
 
 export async function generateMetadata({
   params,
@@ -18,9 +20,22 @@ export async function generateMetadata({
   return pageMetadata(locale, "home");
 }
 
+// FAQ structured data — mirrors the on-page FAQ accordion. Helps rich results and gives
+// AI assistants clean, citable Q&A pairs about the product.
+const faqLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqs.map((f) => ({
+    "@type": "Question",
+    name: f.question,
+    acceptedAnswer: { "@type": "Answer", text: f.answer },
+  })),
+};
+
 function Home() {
   return (
     <main className="overflow-hidden">
+      <JsonLd data={faqLd} />
       <Banner />
       <PainPoints />
       <Solution />

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Banner from "@/components/Home/Banner";
 import PainPoints from "@/components/Home/PainPoints";
 import Solution from "@/components/Home/Solution";
@@ -6,6 +7,16 @@ import Testimonials from "@/components/Home/Testimonials";
 import Pricing from "@/components/Home/Pricing";
 import FAQ from "@/components/Home/FAQ";
 import FinalCTA from "@/components/Home/FinalCTA";
+import { pageMetadata } from "@/lib/seoMetadata";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return pageMetadata(locale, "home");
+}
 
 function Home() {
   return (

--- a/src/app/[locale]/(home)/pricing/page.tsx
+++ b/src/app/[locale]/(home)/pricing/page.tsx
@@ -1,5 +1,16 @@
 import PricingPlans from "@/components/Home/Pricing";
 import React from "react";
+import type { Metadata } from "next";
+import { pageMetadata } from "@/lib/seoMetadata";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return pageMetadata(locale, "pricing", "/pricing");
+}
 
 const page = () => {
   return (

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,18 +1,69 @@
 import React from "react";
 import type { Metadata } from "next";
-import { metadataConst } from "../../constants/AppConstants";
+import { Geist, Geist_Mono } from "next/font/google";
+import "../globals.css";
 import { Providers } from "../providers";
 import { notFound } from "next/navigation";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
-import { routing } from "@/i18n/routing";
 import { getMessages } from "next-intl/server";
+import { routing } from "@/i18n/routing";
+import {
+  DEFAULT_DESCRIPTION,
+  DEFAULT_TITLE,
+  SEO_KEYWORDS,
+  SITE_NAME,
+  SITE_URL,
+  languageAlternates,
+  localizedUrl,
+  ogLocale,
+} from "@/constants/site";
+import { JsonLd } from "@/components/seo/JsonLd";
 
-export const metadata: Metadata = {
-  title: metadataConst.title,
-  description: metadataConst.description,
-};
+const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
+const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
 
-export default async function RootLayout({
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    metadataBase: new URL(SITE_URL),
+    title: { default: DEFAULT_TITLE, template: `%s | ${SITE_NAME}` },
+    description: DEFAULT_DESCRIPTION,
+    applicationName: SITE_NAME,
+    keywords: SEO_KEYWORDS,
+    alternates: { canonical: localizedUrl(locale), languages: languageAlternates() },
+    openGraph: {
+      type: "website",
+      siteName: SITE_NAME,
+      title: DEFAULT_TITLE,
+      description: DEFAULT_DESCRIPTION,
+      url: localizedUrl(locale),
+      locale: ogLocale(locale),
+    },
+    twitter: { card: "summary_large_image", title: DEFAULT_TITLE, description: DEFAULT_DESCRIPTION },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        "max-image-preview": "large",
+        "max-snippet": -1,
+        "max-video-preview": -1,
+      },
+    },
+    other: {
+      // Opt out of the Dark Reader extension, which rewrites the DOM before hydration and
+      // causes mismatches — the app has its own (next-themes) dark mode.
+      "darkreader-lock": "",
+    },
+  };
+}
+
+export default async function LocaleLayout({
   children,
   params,
 }: Readonly<{
@@ -25,9 +76,43 @@ export default async function RootLayout({
   }
   const messages = await getMessages();
 
+  // Site-wide structured data. Organization + WebSite help search engines understand the
+  // brand and can enable richer results (sitelinks, knowledge panel).
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: SITE_URL,
+      logo: `${SITE_URL}/icon.svg`,
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      name: SITE_NAME,
+      applicationCategory: "BusinessApplication",
+      operatingSystem: "Web",
+      description: DEFAULT_DESCRIPTION,
+      url: SITE_URL,
+    },
+  ];
+
   return (
-    <NextIntlClientProvider locale={locale} messages={messages}>
-      <Providers>{children}</Providers>
-    </NextIntlClientProvider>
+    <html lang={locale} suppressHydrationWarning>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#f5f5f5] text-gray-700 dark:bg-[#1a2744] dark:text-indigo-200`}
+      >
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <Providers>{children}</Providers>
+        </NextIntlClientProvider>
+        <JsonLd data={jsonLd} />
+      </body>
+    </html>
   );
 }

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#4338ca"/>
+  <rect x="9" y="6.5" width="14" height="19" rx="2.5" fill="#ffffff"/>
+  <rect x="12" y="11" width="8" height="1.8" rx="0.9" fill="#4338ca"/>
+  <rect x="12" y="15" width="8" height="1.8" rx="0.9" fill="#4338ca"/>
+  <rect x="12" y="19" width="5" height="1.8" rx="0.9" fill="#4338ca"/>
+  <path d="M6 10V7.5A1.5 1.5 0 0 1 7.5 6H10" fill="none" stroke="#a5b4fc" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M26 22v2.5A1.5 1.5 0 0 1 24.5 26H22" fill="none" stroke="#a5b4fc" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,44 +1,10 @@
 import React from "react";
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
-import { metadataConst } from "../constants/AppConstants";
-import { Providers } from "./providers";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
-
-export const metadata: Metadata = {
-  title: metadataConst.title,
-  description: metadataConst.description,
-  other: {
-    // Opt out of the Dark Reader browser extension. The app has its own
-    // (next-themes) dark mode, and Dark Reader rewrites SVG attributes/styles
-    // before React hydrates, causing hydration mismatches. This meta tells the
-    // extension to leave the DOM untouched. See https://github.com/darkreader/darkreader
-    "darkreader-lock": "",
-  },
-};
-
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
-  return (
-    <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#f5f5f5] text-gray-700 dark:bg-[#1a2744] dark:text-indigo-200`}
-      >
-        <Providers>{children}</Providers>
-      </body>
-    </html>
-  );
+/**
+ * Root pass-through. With the next-intl `[locale]` segment, the real <html>/<body> live in
+ * `app/[locale]/layout.tsx` so the `lang` attribute can reflect the active locale (en/nl/de)
+ * — which a top-level root layout can't know. Global metadata is defined there too.
+ */
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return children;
 }

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,9 @@
+import { OG_ALT, OG_CONTENT_TYPE, OG_SIZE, renderOgImage } from "@/components/seo/og";
+
+export const alt = OG_ALT;
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+export default function OpengraphImage() {
+  return renderOgImage();
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/constants/site";
+
+/**
+ * Allow crawling of the public marketing site; keep the authenticated app and auth flows
+ * out of the index. Disallow paths use a wildcard middle segment because every route is
+ * locale-prefixed (e.g. /en/dashboard, /de/workspace).
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [
+        "/api/",
+        "/*/dashboard",
+        "/*/workspace",
+        "/*/uploads",
+        "/*/documents",
+        "/*/profile",
+        "/*/auth/",
+      ],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from "next";
+import { routing } from "@/i18n/routing";
+import { localizedUrl, languageAlternates } from "@/constants/site";
+
+/**
+ * Public, indexable routes only. Each entry lists the default-locale URL with hreflang
+ * alternates for every locale, so search engines discover the localized variants. App and
+ * auth routes are intentionally excluded (they're private / non-indexable).
+ */
+const PUBLIC_PATHS = ["", "/about", "/pricing", "/contact"];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+  return PUBLIC_PATHS.map((path) => ({
+    url: localizedUrl(routing.defaultLocale, path),
+    lastModified,
+    changeFrequency: "weekly",
+    priority: path === "" ? 1 : 0.7,
+    alternates: { languages: languageAlternates(path) },
+  }));
+}

--- a/src/app/twitter-image.tsx
+++ b/src/app/twitter-image.tsx
@@ -1,0 +1,9 @@
+import { OG_ALT, OG_CONTENT_TYPE, OG_SIZE, renderOgImage } from "@/components/seo/og";
+
+export const alt = OG_ALT;
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+export default function TwitterImage() {
+  return renderOgImage();
+}

--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -5,6 +5,7 @@ import AuthButton from "./AuthButton";
 import AuthInput from "./AuthInput";
 import { useLoginForm } from "./Hooks/useLoginForm";
 import { Link } from "@/i18n/navigation";
+import { Wordmark } from "@/components/Wordmark";
 
 export default function LoginForm() {
   const {
@@ -20,7 +21,7 @@ export default function LoginForm() {
     <div className="flex-1 p-6 sm:p-8 flex flex-col justify-center">
       <MotionFadeIn delay={0.3} className="max-w-md mx-auto w-full">
         <h2 className="text-2xl font-bold text-center mb-10 text-gray-800">
-          Welcome back to <span className="text-indigo-500">Panda Parse</span>
+          Welcome back to <Wordmark />
         </h2>
 
         <form onSubmit={handleSubmit} className="space-y-5">

--- a/src/components/Auth/RegisterForm.tsx
+++ b/src/components/Auth/RegisterForm.tsx
@@ -5,6 +5,7 @@ import AuthButton from "./AuthButton";
 import AuthInput from "./AuthInput";
 import { useRegisterForm } from "./Hooks/useRegisterForm";
 import { Link } from "@/i18n/navigation";
+import { Wordmark } from "@/components/Wordmark";
 
 export default function RegisterForm() {
   const {
@@ -20,7 +21,7 @@ export default function RegisterForm() {
     <div className="flex-1 p-6 sm:p-8 flex flex-col justify-center">
       <MotionFadeIn delay={0.3} className="max-w-md mx-auto w-full">
         <h2 className="text-2xl font-bold text-center mb-6 text-gray-800">
-          Create your <span className="text-indigo-500">Panda Parse</span> account
+          Create your <Wordmark /> account
         </h2>
 
         <form onSubmit={handleSubmit} className="space-y-5">

--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -110,7 +110,7 @@
 //                     </svg>
 //                   </div>
 //                   <span className="text-2xl font-bold text-gray-800">
-//                     Panda <span className="text-indigo-500">Parse</span>
+//                     <span className="text-indigo-500">OCR</span>Parse
 //                   </span>
 //                 </motion.div>
 //               </div>

--- a/src/components/Home/FAQ.tsx
+++ b/src/components/Home/FAQ.tsx
@@ -2,33 +2,7 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { FaChevronDown } from "react-icons/fa";
-
-const faqs = [
-  {
-    question: "How accurate is your OCR technology?",
-    answer: "Our AI-powered OCR achieves 99%+ accuracy for standard documents and 95%+ for complex layouts. We continuously train our models on diverse document types to ensure high accuracy across different formats and languages."
-  },
-  {
-    question: "Is my data secure and GDPR compliant?",
-    answer: "Yes, we take data security seriously. All data is processed in EU-based data centers, encrypted in transit and at rest, and automatically deleted according to your retention settings. We are fully GDPR compliant and can sign DPAs as needed."
-  },
-  {
-    question: "How quickly can I get started?",
-    answer: "You can start processing documents within minutes of signing up. Our platform requires no installation - simply upload your documents through our web interface or API. We offer a 14-day free trial with no credit card required."
-  },
-  {
-    question: "What types of documents do you support?",
-    answer: "We support a wide range of documents including invoices, receipts, purchase orders, shipping documents, and general business documents. Our system handles various formats including PDF, JPEG, PNG, and TIFF files."
-  },
-  {
-    question: "Can I integrate with my existing systems?",
-    answer: "Yes, we provide a comprehensive REST API and webhooks for seamless integration with your existing systems. We also offer pre-built integrations with popular accounting and ERP systems."
-  },
-  {
-    question: "What happens if there's an error in the extraction?",
-    answer: "Our platform includes a built-in verification interface where you can review and correct any extraction errors. We also provide confidence scores for each extracted field to help identify potential issues."
-  }
-];
+import { faqs } from "@/constants/faq";
 
 const FAQ = () => {
   const [openIndex, setOpenIndex] = useState<number | null>(null);

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -4,7 +4,8 @@ import React, { useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { Link } from "@/i18n/navigation";
 import useScroll from "@/lib/hooks/useScroll";
-import { brandData, navLinkData } from "@/constants/AppConstants";
+import { navLinkData } from "@/constants/AppConstants";
+import { Wordmark } from "@/components/Wordmark";
 // import DropdownMenu from '../interface/dropdown/NavMenu';
 import CommonModal from "../Interface/modal/CommonModal";
 import ThemeSwitch from "../Interface/CustomFeature/ThemeSwitch";
@@ -44,8 +45,10 @@ const PrimaryNavbar = () => {
     >
       <div className="w-full max-w-8xl h-20 px-10 text-lg font-medium flex gap-4 items-center justify-between">
         <div className="">
-          <div className="lg:text-2xl font-bold text-brandLight dark:text-brandDark drop-shadow-md">
-            <Link href={"/"}>{brandData.name}</Link>
+          <div className="lg:text-2xl font-bold drop-shadow-md">
+            <Link href={"/"} aria-label="OCRParse — home">
+              <Wordmark />
+            </Link>
             {/* <Image src={PrimaryLogo} width={200} height={40} alt='Business Interaspect' /> */}
           </div>
         </div>

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -1,11 +1,12 @@
 "use client";
 //mounted is used to fix a server/client mismatch
-import React, { useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Link } from "@/i18n/navigation";
 import useScroll from "@/lib/hooks/useScroll";
 import { navLinkData } from "@/constants/AppConstants";
 import { Wordmark } from "@/components/Wordmark";
+import { useAuth } from "@/lib/hooks/useAuth";
 // import DropdownMenu from '../interface/dropdown/NavMenu';
 import CommonModal from "../Interface/modal/CommonModal";
 import ThemeSwitch from "../Interface/CustomFeature/ThemeSwitch";
@@ -26,16 +27,26 @@ const PrimaryNavbar = () => {
 
   const scrolled = useScroll(50);
   const router = useRouter();
-  const pathname = usePathname();
-  console.log("pathname", pathname);
 
-  // const handleLogout = () => {
-  //   router.push('/');
-  // };
+  const { user, isAuthenticated, logout } = useAuth();
+  // The auth store rehydrates from localStorage on the client, so the server
+  // always renders logged-out. Gate the auth-dependent UI on `mounted` to avoid
+  // a hydration mismatch (and a flash of "Sign in" for logged-in users).
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   const handleNavLinkClick = (link: string) => {
     router.push(link);
   };
+
+  const handleLogout = () => {
+    if (confirm("Are you sure you want to log out?")) {
+      logout();
+      router.push("/");
+    }
+  };
+
+  const firstName = user?.name?.trim().split(" ")[0] || "Account";
 
   return (
     <div
@@ -95,9 +106,48 @@ const PrimaryNavbar = () => {
         </div>
         <div className="justify-between flex lg:w-72 bg-red-10">
           <div className="lg:px-3 py-2.5 flex gap-2 justify-between items-center">
-            <Link href={"/auth/login"} className="px-2 font-semibold bg-white/0 text-brandLight dark:text-indigo-200">
-              Sign in
-            </Link>
+            {!mounted ? (
+              // Placeholder keeps layout stable until auth state hydrates.
+              <div className="px-2 h-6 w-16" aria-hidden />
+            ) : isAuthenticated && user ? (
+              <Dropdown title={firstName}>
+                <div className="flex flex-col gap-1 p-1 items-start min-w-52">
+                  <div className="px-2 py-1.5 w-full border-b border-gray-100 dark:border-gray-800">
+                    <div className="font-semibold text-gray-800 dark:text-gray-100 truncate">{user.name}</div>
+                    <div className="text-sm text-gray-400 truncate">{user.email}</div>
+                  </div>
+                  <MenuItem>
+                    <Link
+                      href="/dashboard"
+                      className="w-full text-left p-2 rounded-2xl hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-brandLight dark:hover:text-brandDark"
+                    >
+                      Dashboard
+                    </Link>
+                  </MenuItem>
+                  <MenuItem>
+                    <Link
+                      href="/profile"
+                      className="w-full text-left p-2 rounded-2xl hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-brandLight dark:hover:text-brandDark"
+                    >
+                      Profile
+                    </Link>
+                  </MenuItem>
+                  <MenuItem>
+                    <button
+                      onClick={handleLogout}
+                      className="w-full text-left p-2 rounded-2xl text-red-600 hover:bg-gray-100 dark:hover:bg-gray-800"
+                      type="button"
+                    >
+                      Log out
+                    </button>
+                  </MenuItem>
+                </div>
+              </Dropdown>
+            ) : (
+              <Link href={"/auth/login"} className="px-2 font-semibold bg-white/0 text-brandLight dark:text-indigo-200">
+                Sign in
+              </Link>
+            )}
             <LanguageSwitch />
             <ThemeSwitch />
           </div>

--- a/src/components/Wordmark.tsx
+++ b/src/components/Wordmark.tsx
@@ -8,8 +8,8 @@ import React from "react";
 export function Wordmark({ className = "" }: { className?: string }) {
   return (
     <span className={className}>
-      <span className="font-bold text-brandLight dark:text-brandDark">OCR</span>
-      <span className="font-normal text-gray-700 dark:text-gray-300">Parse</span>
+      <span className="font-extrabold text-brandLight dark:text-brandDark">OCR</span>
+      <span className="font-medium text-gray-700 dark:text-gray-300">Parse</span>
     </span>
   );
 }

--- a/src/components/Wordmark.tsx
+++ b/src/components/Wordmark.tsx
@@ -8,8 +8,8 @@ import React from "react";
 export function Wordmark({ className = "" }: { className?: string }) {
   return (
     <span className={className}>
-      <span className="text-brandLight dark:text-brandDark">OCR</span>
-      <span className="text-gray-700 dark:text-gray-300">Parse</span>
+      <span className="font-bold text-brandLight dark:text-brandDark">OCR</span>
+      <span className="font-normal text-gray-700 dark:text-gray-300">Parse</span>
     </span>
   );
 }

--- a/src/components/Wordmark.tsx
+++ b/src/components/Wordmark.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+/**
+ * The OCRParse wordmark: "OCR" in the brand color, "Parse" in dark gray. Rendered as a
+ * single inline element so it can be dropped into headings, the navbar, or auth screens
+ * and inherit their font size/weight.
+ */
+export function Wordmark({ className = "" }: { className?: string }) {
+  return (
+    <span className={className}>
+      <span className="text-brandLight dark:text-brandDark">OCR</span>
+      <span className="text-gray-700 dark:text-gray-300">Parse</span>
+    </span>
+  );
+}

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+/**
+ * Renders a JSON-LD structured-data block. Server component — safe to place anywhere in
+ * the tree. `<` is escaped so a value can never prematurely close the <script> element.
+ */
+export function JsonLd({
+  data,
+}: {
+  data: Record<string, unknown> | Record<string, unknown>[];
+}) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data).replace(/</g, "\\u003c") }}
+    />
+  );
+}

--- a/src/components/seo/og.tsx
+++ b/src/components/seo/og.tsx
@@ -1,0 +1,66 @@
+import { ImageResponse } from "next/og";
+import { DEFAULT_TITLE, SITE_NAME } from "@/constants/site";
+
+/**
+ * Shared 1200×630 social-share image, rendered on demand by `next/og` (no external
+ * dependency, no static asset to maintain). Consumed by both the Open Graph and Twitter
+ * image route conventions so they stay identical.
+ */
+
+export const OG_SIZE = { width: 1200, height: 630 };
+export const OG_ALT = DEFAULT_TITLE;
+export const OG_CONTENT_TYPE = "image/png";
+
+export function renderOgImage(): ImageResponse {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "80px",
+          background: "linear-gradient(135deg, #1a2744 0%, #312e81 60%, #4338ca 100%)",
+          color: "#ffffff",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "20px" }}>
+          <div
+            style={{
+              width: "64px",
+              height: "64px",
+              borderRadius: "16px",
+              background: "#ffffff",
+              color: "#4338ca",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: "40px",
+              fontWeight: 800,
+            }}
+          >
+            O
+          </div>
+          <div style={{ fontSize: "40px", fontWeight: 700, letterSpacing: "-1px" }}>
+            {SITE_NAME}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+          <div style={{ fontSize: "68px", fontWeight: 800, lineHeight: 1.1, letterSpacing: "-2px" }}>
+            Accurate OCR for invoices, receipts & documents
+          </div>
+          <div style={{ fontSize: "34px", color: "#c7d2fe", lineHeight: 1.3 }}>
+            Turn documents into structured JSON/CSV data in seconds.
+          </div>
+        </div>
+
+        <div style={{ fontSize: "28px", color: "#a5b4fc" }}>ocrparse.com</div>
+      </div>
+    ),
+    { ...OG_SIZE },
+  );
+}

--- a/src/constants/AppConstants.ts
+++ b/src/constants/AppConstants.ts
@@ -28,7 +28,7 @@ export const navLinkData: NavLink[] = [
 ];
 
 export const brandData = {
-  name: `Panda Parse`,
+  name: `OCRParse`,
   slogan: `. . .`,
   address: `Add Address`,
 };

--- a/src/constants/AppConstants.ts
+++ b/src/constants/AppConstants.ts
@@ -2,8 +2,9 @@ import { NavLink } from "@/types/Home/banner";
 import { Upload, History, Settings, BarChart3, Folder, Home } from "lucide-react";
 
 export const metadataConst = {
-  title: "Dev",
-  description: "Add Description",
+  title: "OCRParse — Accurate OCR for invoices, receipts & documents",
+  description:
+    "Transform invoices, receipts, and documents into structured JSON/CSV data in seconds. OCRParse's AI extracts and structures your data with industry-leading accuracy.",
 };
 
 export const navLinkData: NavLink[] = [

--- a/src/constants/faq.ts
+++ b/src/constants/faq.ts
@@ -1,0 +1,43 @@
+/**
+ * FAQ content — single source of truth for both the on-page FAQ accordion and the
+ * FAQPage structured data emitted on the home page. Keeping them in sync matters for SEO
+ * and for AI assistants that cite Q&A pairs; Google requires the schema to match visible
+ * content.
+ */
+export interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+export const faqs: FaqItem[] = [
+  {
+    question: "How accurate is your OCR technology?",
+    answer:
+      "Our AI-powered OCR achieves 99%+ accuracy for standard documents and 95%+ for complex layouts. We continuously train our models on diverse document types to ensure high accuracy across different formats and languages.",
+  },
+  {
+    question: "Is my data secure and GDPR compliant?",
+    answer:
+      "Yes, we take data security seriously. All data is processed in EU-based data centers, encrypted in transit and at rest, and automatically deleted according to your retention settings. We are fully GDPR compliant and can sign DPAs as needed.",
+  },
+  {
+    question: "How quickly can I get started?",
+    answer:
+      "You can start processing documents within minutes of signing up. Our platform requires no installation - simply upload your documents through our web interface or API. We offer a 14-day free trial with no credit card required.",
+  },
+  {
+    question: "What types of documents do you support?",
+    answer:
+      "We support a wide range of documents including invoices, receipts, purchase orders, shipping documents, and general business documents. Our system handles various formats including PDF, JPEG, PNG, and TIFF files.",
+  },
+  {
+    question: "Can I integrate with my existing systems?",
+    answer:
+      "Yes, we provide a comprehensive REST API and webhooks for seamless integration with your existing systems. We also offer pre-built integrations with popular accounting and ERP systems.",
+  },
+  {
+    question: "What happens if there's an error in the extraction?",
+    answer:
+      "Our platform includes a built-in verification interface where you can review and correct any extraction errors. We also provide confidence scores for each extracted field to help identify potential issues.",
+  },
+];

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -1,0 +1,50 @@
+import { routing } from "@/i18n/routing";
+
+/**
+ * Site-wide SEO constants and URL helpers. Centralized so metadata, the sitemap, robots,
+ * canonical/hreflang alternates and structured data all speak the same canonical origin.
+ *
+ * `localePrefix` is next-intl's default ("always"), so every public URL is `/{locale}{path}`.
+ */
+
+/** Canonical production origin, no trailing slash. Override per-env with NEXT_PUBLIC_SITE_URL. */
+export const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.ocrparse.com").replace(
+  /\/+$/,
+  "",
+);
+
+export const SITE_NAME = "OCRParse";
+
+export const DEFAULT_TITLE = "OCRParse — Accurate OCR for invoices, receipts & documents";
+export const DEFAULT_DESCRIPTION =
+  "Transform invoices, receipts, and documents into structured JSON/CSV data in seconds. OCRParse's AI extracts and structures your data with industry-leading accuracy.";
+
+export const SEO_KEYWORDS = [
+  "OCR",
+  "invoice OCR",
+  "receipt OCR",
+  "document data extraction",
+  "invoice data extraction",
+  "PDF to JSON",
+  "PDF to CSV",
+  "accounts payable automation",
+  "AP automation",
+  "structured data extraction",
+];
+
+/** Map an app locale to an Open Graph `og:locale` value. */
+const OG_LOCALE: Record<string, string> = { en: "en_US", nl: "nl_NL", de: "de_DE" };
+export const ogLocale = (locale: string): string => OG_LOCALE[locale] ?? "en_US";
+
+/** Absolute URL for a locale + path. `path` starts with "/" (or is "" for the home page). */
+export function localizedUrl(locale: string, path = ""): string {
+  return `${SITE_URL}/${locale}${path}`;
+}
+
+/** hreflang alternates map for a path: every locale plus `x-default` → the default locale. */
+export function languageAlternates(path = ""): Record<string, string> {
+  const languages: Record<string, string> = {};
+  for (const locale of routing.locales) languages[locale] = localizedUrl(locale, path);
+  languages["x-default"] = localizedUrl(routing.defaultLocale, path);
+  return languages;
+}

--- a/src/lib/seoMetadata.ts
+++ b/src/lib/seoMetadata.ts
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { languageAlternates, localizedUrl } from "@/constants/site";
+
+/**
+ * Build localized page metadata (title/description/canonical/hreflang/OG) from a
+ * `Meta.<key>` message namespace and the route's path. Server-only — call from a page's
+ * `generateMetadata`. The home page (path "") uses an absolute title; other pages inherit
+ * the `%s | OCRParse` template from the root layout.
+ */
+export async function pageMetadata(
+  locale: string,
+  key: string,
+  path = "",
+): Promise<Metadata> {
+  const t = await getTranslations({ locale, namespace: `Meta.${key}` });
+  const url = localizedUrl(locale, path);
+  return {
+    title: path === "" ? { absolute: t("title") } : t("title"),
+    description: t("description"),
+    alternates: { canonical: url, languages: languageAlternates(path) },
+    openGraph: { title: t("title"), description: t("description"), url },
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,5 +5,7 @@ import { routing } from "./i18n/routing";
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: "/((?!api|trpc|_next|_vercel|.*\\..*).*)",
+  // Exclude API/internal paths, files with an extension (icon.svg, sitemap.xml, robots.txt),
+  // and the extensionless metadata image routes so they aren't locale-redirected.
+  matcher: "/((?!api|trpc|_next|_vercel|opengraph-image|twitter-image|.*\\..*).*)",
 };


### PR DESCRIPTION
The marketing site shipped with **placeholder metadata** — title `Dev`, description `Add Description` — and no discovery or social infrastructure, which is why `site:ocrparse.com` surfaces almost nothing. This PR ships a complete SEO layer **and** renames the product from *Panda Parse* to **OCRParse** everywhere it is user-facing.

## Rebrand → OCRParse
- New `Wordmark` component renders **OCR** in the brand color and **Parse** in dark gray; wired into the navbar logo and both auth (login/register) headings.
- Renamed brand string (`brandData.name`), workspace/document page titles, and README. The name is now the single word **OCRParse**.
- The functional production API hostname (`api.pandaparse.com` in `src/lib/env.ts`) is **intentionally left unchanged** — it is an infra endpoint, not a display name. Change it only if the backend has actually moved.

## Foundational metadata
- Central site constants (canonical origin, brand, default title/description, keywords) + URL/hreflang helpers; origin overridable via `NEXT_PUBLIC_SITE_URL` (defaults to `https://www.ocrparse.com`).
- Locale-aware root metadata: `metadataBase`, title template (`%s | OCRParse`), Open Graph, Twitter card, keywords, `index/follow` robots defaults.
- Per-page localized metadata for **home / about / pricing / contact**, pulled from a new `Meta` namespace in **en / nl / de**, each with `canonical` + `hreflang` alternates (incl. `x-default`).
- Auth pages and the entire authenticated app are `noindex, nofollow`.

## Discovery & social
- Dynamic **`sitemap.xml`** (public routes × locales with hreflang alternates) and **`robots.txt`** (disallows app/auth/api, references the sitemap).
- Branded **favicon** (`icon.svg`) and on-demand 1200×630 **Open Graph / Twitter images** via `next/og` — no static asset to maintain, no extra dependency.
- **JSON-LD**: Organization + WebSite + SoftwareApplication, site-wide.

## AI / LLM discoverability
- Home **FAQ** extracted into `src/constants/faq.ts` as a single source of truth shared by the on-page accordion and new **FAQPage JSON-LD**, so structured data always matches visible content (Google requirement) and AI assistants get clean, citable Q&A pairs.
- Added **`public/llms.txt`** (llmstxt.org format) describing the product, capabilities, key pages, and facts for AI assistants.

## i18n correctness
- Moved `<html>`/`<body>` into the `[locale]` layout so `lang` reflects the active locale (was always `en`); root layout is now a pass-through (standard next-intl pattern). Middleware matcher updated so the OG/Twitter image routes aren't locale-redirected.

## Verification
Production build + typecheck clean. Confirmed: real localized `<title>` (no more "Dev"), canonical + hreflang, OG/Twitter tags, valid 1200×630 PNG social image, `sitemap.xml`, `robots.txt`, per-locale `<html lang>` (`en`/`de`), `noindex` on auth, FAQPage JSON-LD on home, and the two-tone OCRParse wordmark.

**No external SEO package** — Next 15's native metadata/sitemap/robots/`next/og` cover everything and supersede `next-seo`/`next-sitemap`.

### Follow-ups (not in this PR)
- The **About page is an empty placeholder** (`<div/>`) — it has metadata and is in the sitemap, but needs real content to rank. Consider adding content or removing it from the sitemap until then.
- Confirm the **backend API domain**: `api.pandaparse.com` was left as-is; update it (and any DNS) only if the API has moved to `ocrparse.com`.
- Set `NEXT_PUBLIC_SITE_URL` in the production env if the canonical host should differ from `https://www.ocrparse.com`.
