### PR TITLE
feat(auth): Continue with Google (sign-in & sign-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Backend API base URL (must include the /api prefix)
+NEXT_PUBLIC_API_URL=https://api.ocrparse.com/api
+
+# Canonical site origin used for SEO metadata (optional; defaults to https://www.ocrparse.com)
+NEXT_PUBLIC_SITE_URL=https://www.ocrparse.com
+
+# S3 bucket for document uploads
+NEXT_PUBLIC_S3_BUCKET_NAME=s3-ocrparse-invoice-documents-input
+
+# Google Sign-In — OAuth 2.0 Web client ID from Google Cloud Console.
+# Must match GOOGLE_CLIENT_ID on the backend (it is the ID-token audience).
+# Leave empty to hide the "Continue with Google" button.
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-oauth-web-client-id.apps.googleusercontent.com

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ jspm_packages/
 .env.*
 .env.local
 .env.production
+!.env.example
 
 # TypeScript
 dist/

--- a/src/components/Auth/AuthDivider.tsx
+++ b/src/components/Auth/AuthDivider.tsx
@@ -1,0 +1,12 @@
+export default function AuthDivider({ label = "or" }: { label?: string }) {
+  return (
+    <div className="relative my-5">
+      <div className="absolute inset-0 flex items-center" aria-hidden>
+        <div className="w-full border-t border-gray-200 dark:border-gray-700" />
+      </div>
+      <div className="relative flex justify-center text-sm">
+        <span className="px-3 bg-white dark:bg-gray-900 text-gray-500">{label}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Auth/GoogleAuthButton.tsx
+++ b/src/components/Auth/GoogleAuthButton.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Script from "next/script";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "@/i18n/navigation";
+import authApi from "@/lib/api/auth";
+import { useAuthStore } from "@/lib/auth/authStore";
+import env from "@/lib/env";
+
+const GSI_SRC = "https://accounts.google.com/gsi/client";
+
+type GoogleButtonText = "signin_with" | "signup_with" | "continue_with";
+
+/**
+ * "Continue with Google" button backed by Google Identity Services.
+ *
+ * GIS renders its own (compliant) button, hands us a Google ID token on success,
+ * and we exchange it at POST /auth/google for our own JWTs — reusing the exact
+ * same auth-store login path as email/password sign-in. Renders nothing when
+ * NEXT_PUBLIC_GOOGLE_CLIENT_ID is not configured.
+ */
+export default function GoogleAuthButton({ text = "continue_with" }: { text?: GoogleButtonText }) {
+  const clientId = env.googleClientId;
+  const { login } = useAuthStore();
+  const router = useRouter();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const renderedRef = useRef(false);
+  const [scriptLoaded, setScriptLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const googleMutation = useMutation({
+    mutationFn: (idToken: string) => authApi.googleLogin(idToken),
+    onSuccess: (response) => {
+      const { user, access_token, refresh_token } = response.data;
+      login(
+        { accessToken: access_token, refreshToken: refresh_token },
+        {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          role: user.role,
+          userType: user.userType,
+          companyName: user.companyName,
+          image: user.image,
+        }
+      );
+      router.push("/dashboard");
+    },
+    onError: () => {
+      setError("Google sign-in failed. Please try again.");
+    },
+  });
+
+  // Keep the latest handler in a ref so GIS is initialized only once (its callback
+  // can't be swapped after initialize), without stale closures over the mutation.
+  const handleCredential = useCallback(
+    (response: GoogleCredentialResponse) => {
+      if (!response.credential) {
+        setError("No credential returned from Google.");
+        return;
+      }
+      setError(null);
+      googleMutation.mutate(response.credential);
+    },
+    [googleMutation]
+  );
+  const handlerRef = useRef(handleCredential);
+  handlerRef.current = handleCredential;
+
+  useEffect(() => {
+    if (!scriptLoaded || !clientId || renderedRef.current) return;
+    const google = window.google;
+    const container = containerRef.current;
+    if (!google || !container) return;
+
+    google.accounts.id.initialize({
+      client_id: clientId,
+      callback: (response) => handlerRef.current(response),
+      cancel_on_tap_outside: true,
+    });
+    google.accounts.id.renderButton(container, {
+      type: "standard",
+      theme: "outline",
+      size: "large",
+      text,
+      shape: "rectangular",
+      logo_alignment: "center",
+      width: container.offsetWidth || 320,
+    });
+    renderedRef.current = true;
+  }, [scriptLoaded, clientId, text]);
+
+  if (!clientId) return null;
+
+  return (
+    <div className="w-full">
+      <Script src={GSI_SRC} strategy="afterInteractive" onLoad={() => setScriptLoaded(true)} />
+      <div ref={containerRef} className="flex w-full justify-center min-h-[44px]" />
+      {googleMutation.isPending && (
+        <p className="mt-2 text-center text-sm text-gray-500">Signing you in…</p>
+      )}
+      {error && <p className="mt-2 text-center text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/Auth/Hooks/useLoginForm.tsx
+++ b/src/components/Auth/Hooks/useLoginForm.tsx
@@ -36,6 +36,7 @@ export function useLoginForm() {
           role: response.data.user.role,
           userType: response.data.user.userType,
           companyName: response.data.user.companyName,
+          image: response.data.user.image,
         }
       );
     },

--- a/src/components/Auth/Hooks/useRegisterForm.tsx
+++ b/src/components/Auth/Hooks/useRegisterForm.tsx
@@ -48,6 +48,7 @@ export function useRegisterForm() {
           role: response.data.user.role,
           userType: response.data.user.userType,
           companyName: response.data.user.companyName,
+          image: response.data.user.image,
         }
       );
     },

--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -6,6 +6,8 @@ import AuthInput from "./AuthInput";
 import { useLoginForm } from "./Hooks/useLoginForm";
 import { Link } from "@/i18n/navigation";
 import { Wordmark } from "@/components/Wordmark";
+import GoogleAuthButton from "./GoogleAuthButton";
+import AuthDivider from "./AuthDivider";
 
 export default function LoginForm() {
   const {
@@ -67,6 +69,11 @@ export default function LoginForm() {
           <AuthButton type="submit" isLoading={isSubmitting} delay={0.6}>
             {isSubmitting ? "Signing in..." : "Sign in"}
           </AuthButton>
+
+          <MotionFadeIn delay={0.65}>
+            <AuthDivider />
+            <GoogleAuthButton text="continue_with" />
+          </MotionFadeIn>
 
           <MotionFadeIn delay={0.7} className="text-center">
             <span className="text-gray-600">New here? </span>

--- a/src/components/Auth/RegisterForm.tsx
+++ b/src/components/Auth/RegisterForm.tsx
@@ -6,6 +6,8 @@ import AuthInput from "./AuthInput";
 import { useRegisterForm } from "./Hooks/useRegisterForm";
 import { Link } from "@/i18n/navigation";
 import { Wordmark } from "@/components/Wordmark";
+import GoogleAuthButton from "./GoogleAuthButton";
+import AuthDivider from "./AuthDivider";
 
 export default function RegisterForm() {
   const {
@@ -71,6 +73,11 @@ export default function RegisterForm() {
           <AuthButton type="submit" isLoading={isSubmitting} delay={0.5}>
             {isSubmitting ? "Creating Account..." : "Create Account"}
           </AuthButton>
+
+          <MotionFadeIn delay={0.55}>
+            <AuthDivider />
+            <GoogleAuthButton text="signup_with" />
+          </MotionFadeIn>
 
           <MotionFadeIn delay={0.6} className="text-center">
             <span className="text-gray-600">Already have an account? </span>

--- a/src/components/Auth/UserAvatar.tsx
+++ b/src/components/Auth/UserAvatar.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+
+interface UserAvatarProps {
+  name: string;
+  image?: string | null;
+  /** Tailwind size classes, e.g. "h-8 w-8". */
+  sizeClassName?: string;
+  /** Tailwind text size for the fallback initial, e.g. "text-sm". */
+  textClassName?: string;
+  className?: string;
+}
+
+/**
+ * Circular user avatar: shows the profile picture (e.g. from Google) when available
+ * and falls back to the first letter of the name — also if the image fails to load.
+ */
+export default function UserAvatar({
+  name,
+  image,
+  sizeClassName = "h-8 w-8",
+  textClassName = "text-sm",
+  className = "",
+}: UserAvatarProps) {
+  const [failed, setFailed] = useState(false);
+  const initial = name?.charAt(0).toUpperCase() || "?";
+
+  if (image && !failed) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={image}
+        alt={name}
+        referrerPolicy="no-referrer"
+        onError={() => setFailed(true)}
+        className={`${sizeClassName} rounded-full object-cover ${className}`}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`${sizeClassName} rounded-full bg-indigo-500 flex items-center justify-center ${className}`}
+    >
+      <span className={`${textClassName} font-medium text-white`}>{initial}</span>
+    </div>
+  );
+}

--- a/src/components/Auth/UserProfile.tsx
+++ b/src/components/Auth/UserProfile.tsx
@@ -2,6 +2,7 @@
 
 import { useAuthUser } from "@/lib/hooks/useAuth";
 import LogoutButton from "./LogoutButton";
+import UserAvatar from "./UserAvatar";
 
 interface UserProfileProps {
   showLogout?: boolean;
@@ -17,9 +18,7 @@ export default function UserProfile({ showLogout = true, className = "flex items
     <div className={className}>
       <div className="flex items-center space-x-3">
         {/* User Avatar */}
-        <div className="h-8 w-8 rounded-full bg-indigo-500 flex items-center justify-center">
-          <span className="text-sm font-medium text-white">{user.name.charAt(0).toUpperCase()}</span>
-        </div>
+        <UserAvatar name={user.name} image={user.image} sizeClassName="h-8 w-8" textClassName="text-sm" />
 
         {/* User Info */}
         <div className="flex flex-col">
@@ -42,9 +41,7 @@ export function UserProfileCompact() {
 
   return (
     <div className="flex items-center space-x-2">
-      <div className="h-6 w-6 rounded-full bg-indigo-500 flex items-center justify-center">
-        <span className="text-xs font-medium text-white">{user.name.charAt(0).toUpperCase()}</span>
-      </div>
+      <UserAvatar name={user.name} image={user.image} sizeClassName="h-6 w-6" textClassName="text-xs" />
       <span className="text-sm text-gray-700 dark:text-gray-300">{user.name}</span>
     </div>
   );

--- a/src/components/Navbar/AppNavbar.tsx
+++ b/src/components/Navbar/AppNavbar.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from "next-intl";
 import ThemeSwitch from "../Interface/CustomFeature/ThemeSwitch";
 import LanguageDropdown from "../Interface/CustomFeature/LanguageSwitch";
 import { useAuthStore } from "@/lib/auth/authStore";
+import UserAvatar from "../Auth/UserAvatar";
 import React from "react";
 
 const AppNavbar = () => {
@@ -23,9 +24,7 @@ const AppNavbar = () => {
               <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{user.name}</p>
               <p className="text-xs text-gray-500 dark:text-gray-400">{user.email}</p>
             </div>
-            <div className="h-8 w-8 rounded-full bg-indigo-500 flex items-center justify-center">
-              <span className="text-sm font-medium text-white">{user.name.charAt(0).toUpperCase()}</span>
-            </div>
+            <UserAvatar name={user.name} image={user.image} sizeClassName="h-8 w-8" textClassName="text-sm" />
           </div>
         )}
 

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -28,9 +28,14 @@ export interface User {
   companyName?: string;
   role: number; // 0=ADMIN, 1=INTERNAL, 2=USER
   userType: number; // 0=INDIVIDUAL_FREELANCER, 1=COMPANY_USER, 2=COMPANY_OWNER
+  image?: string | null; // profile picture URL (e.g. from Google)
   emailVerified: boolean;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface GoogleLoginRequest {
+  idToken: string;
 }
 
 export interface RefreshTokenResponse {
@@ -58,6 +63,11 @@ export const authApi = {
     // The forms will handle storing tokens and user data
 
     return response;
+  },
+
+  // Sign in / sign up with a Google ID token (credential from Google Identity Services)
+  googleLogin: async (idToken: string): Promise<ApiResponse<AuthResponse>> => {
+    return api.post<AuthResponse>("/auth/google", { idToken } as GoogleLoginRequest);
   },
 
   // Logout user

--- a/src/lib/auth/storage.ts
+++ b/src/lib/auth/storage.ts
@@ -10,6 +10,7 @@ export interface StoredUser {
   role: number; // 0=ADMIN, 1=INTERNAL, 2=USER
   userType: number; // 0=INDIVIDUAL_FREELANCER, 1=COMPANY_USER, 2=COMPANY_OWNER
   companyName?: string;
+  image?: string | null; // profile picture URL (e.g. from Google)
 }
 
 export interface AuthTokens {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,6 +1,7 @@
 // Environment configuration and validation
 interface EnvironmentConfig {
   NEXT_PUBLIC_API_URL: string;
+  NEXT_PUBLIC_GOOGLE_CLIENT_ID: string;
   NODE_ENV: "development" | "production" | "test";
 }
 
@@ -22,6 +23,7 @@ class Environment {
   private validateAndLoadConfig(): EnvironmentConfig {
     const config = {
       NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || "",
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "",
       NODE_ENV: (process.env.NODE_ENV as "development" | "production" | "test") || "development",
     };
 
@@ -79,6 +81,11 @@ class Environment {
 
   public get apiUrl(): string {
     return this.config.NEXT_PUBLIC_API_URL;
+  }
+
+  /** Google OAuth Web client ID. Empty string when Google sign-in is not configured. */
+  public get googleClientId(): string {
+    return this.config.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
   }
 
   public get nodeEnv(): string {

--- a/src/types/google-gsi.d.ts
+++ b/src/types/google-gsi.d.ts
@@ -1,0 +1,38 @@
+// Minimal typings for the Google Identity Services (GIS) client loaded from
+// https://accounts.google.com/gsi/client — only the surface we use.
+
+interface GoogleCredentialResponse {
+  credential?: string;
+  select_by?: string;
+}
+
+interface GoogleIdConfiguration {
+  client_id: string;
+  callback: (response: GoogleCredentialResponse) => void;
+  auto_select?: boolean;
+  cancel_on_tap_outside?: boolean;
+  ux_mode?: "popup" | "redirect";
+}
+
+interface GoogleButtonOptions {
+  type?: "standard" | "icon";
+  theme?: "outline" | "filled_blue" | "filled_black";
+  size?: "large" | "medium" | "small";
+  text?: "signin_with" | "signup_with" | "continue_with" | "signin";
+  shape?: "rectangular" | "pill" | "circle" | "square";
+  logo_alignment?: "left" | "center";
+  width?: number | string;
+}
+
+interface Window {
+  google?: {
+    accounts: {
+      id: {
+        initialize: (config: GoogleIdConfiguration) => void;
+        renderButton: (parent: HTMLElement, options: GoogleButtonOptions) => void;
+        prompt: () => void;
+        disableAutoSelect: () => void;
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Continue with Google

Adds a "Continue with Google" button to the **login** and **register** screens, backed by Google Identity Services.

Flow: GIS renders its own compliant button → on success it hands us a Google **ID token** → we POST it to the backend's new `POST /auth/google` → the backend returns the same `{ access_token, refresh_token, user }` as email/password login → it flows through the **existing** Zustand/localStorage `login()` path unchanged, then redirects to the dashboard. No callback route, no tokens in the URL, no locale-prefixed redirect juggling.

### Changes
- **`GoogleAuthButton`** — loads the GSI client via `next/script`, renders Google's button, exchanges the credential with `authApi.googleLogin`, logs in, redirects. Renders **nothing** when `NEXT_PUBLIC_GOOGLE_CLIENT_ID` is unset, so it's safe to merge before the client ID exists.
- **Profile picture end-to-end** — added `image` to the `User` API type and `StoredUser`, threaded through the login/register success mapping, and rendered via a new **`UserAvatar`** (image with initial-letter fallback, and it falls back again if the image 404s) in `UserProfile` and the app navbar.
- **`AuthDivider`** ("or"), minimal GSI type declarations, and a tracked **`.env.example`** documenting `NEXT_PUBLIC_GOOGLE_CLIENT_ID` and the other `NEXT_PUBLIC_*` vars.

### Base branch
This is **stacked on `feat/seo-optimization`** (PR #26) because it builds on the OCRParse wordmark and auth-aware navbar from that PR. Merge #26 first, then this — or retarget this PR to `main` once #26 lands.

### Config
Set `NEXT_PUBLIC_GOOGLE_CLIENT_ID` to the OAuth 2.0 **Web** client ID from Google Cloud Console (same value as the backend's `GOOGLE_CLIENT_ID`). In the Google console, add your site origin(s) to **Authorized JavaScript origins** (e.g. `http://localhost:3210`, `https://www.ocrparse.com`).

### Verification
`tsc --noEmit` and `next build` both pass. Live Google verification requires a real client ID + the backend endpoint deployed.
